### PR TITLE
feature(core): allow implementers to override the action done when a message is failed to be consumed #216

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Then simply call
 
 Extend the EventConsumer, set enableConsumption parameter to true, and it will automatically start consuming messages
 using your consume method.
+The default case when the consumption fails is to log the exception with warn level
+It is allowed change that behavior by override onFailure method
 
 ```kotlin
 class BookingEventConsumer : EventConsumer() {
@@ -118,6 +120,11 @@ class BookingEventConsumer : EventConsumer() {
     override fun getBusType(): BusType {
         return BusType.SQS
 
+    }
+    
+    //override failure behavior and change the log lvl to error
+    override fun onFailure(throwable: Throwable, message: Any) {
+        logger.error { "error ${throwable.message} happened while processing the message $message" }
     }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.katanox</groupId>
     <artifactId>tabour</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <name>Tabour</name>
     <url>https://github.com/katanox/tabour</url>
     <description>Kotlin's library to make working with queues/topics much easier.</description>

--- a/src/main/kotlin/com/katanox/tabour/core/EventConsumer.kt
+++ b/src/main/kotlin/com/katanox/tabour/core/EventConsumer.kt
@@ -3,14 +3,18 @@ package com.katanox.tabour.core
 import com.katanox.tabour.base.IEventHandlerBase
 import com.katanox.tabour.factory.BusType
 import com.katanox.tabour.factory.EventHandlerFactory
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
 import javax.annotation.PostConstruct
+
+private val logger = KotlinLogging.logger {}
 
 abstract class EventConsumer {
 
     private lateinit var handler: IEventHandlerBase
 
-    @Autowired private lateinit var eventHandlerFactory: EventHandlerFactory
+    @Autowired
+    private lateinit var eventHandlerFactory: EventHandlerFactory
 
     abstract fun getBusURL(): String
 
@@ -18,9 +22,23 @@ abstract class EventConsumer {
 
     abstract fun consume(message: String)
 
+    /**
+     * The action that will be executed in case of failure to consume a message.
+     * default behavior is to log the exception.
+     *
+     * Possible to be overridden by the consumer to execute different action
+     */
+    open fun onFailure(throwable: Throwable, message: Any) {
+        logger.warn { "error ${throwable.message} happened while processing the message $message" }
+    }
+
     @PostConstruct
     private fun setUp() {
-        handler =
-            eventHandlerFactory.getEventHandler(getBusType(), getBusURL()) { consume(it as String) }
+        handler = eventHandlerFactory.getEventHandler(
+            getBusType(),
+            getBusURL(),
+            { consume(it) },
+            { throwable, message -> onFailure(throwable, message) }
+        )
     }
 }

--- a/src/main/kotlin/com/katanox/tabour/extentions/ConsumerAction.kt
+++ b/src/main/kotlin/com/katanox/tabour/extentions/ConsumerAction.kt
@@ -1,3 +1,4 @@
 package com.katanox.tabour.extentions
 
 typealias ConsumerAction = (String) -> Unit
+typealias FailureAction = (Throwable, Any) -> Unit

--- a/src/main/kotlin/com/katanox/tabour/factory/EventHandlerFactory.kt
+++ b/src/main/kotlin/com/katanox/tabour/factory/EventHandlerFactory.kt
@@ -2,6 +2,8 @@ package com.katanox.tabour.factory
 
 import com.katanox.tabour.base.IEventHandlerBase
 import com.katanox.tabour.config.TabourAutoConfigs
+import com.katanox.tabour.extentions.ConsumerAction
+import com.katanox.tabour.extentions.FailureAction
 import com.katanox.tabour.integration.sqs.core.consumer.SqsEventHandler
 import java.util.EnumMap
 
@@ -13,10 +15,15 @@ class EventHandlerFactory(private val tabourAutoConfigs: TabourAutoConfigs) {
         BusType.values().forEach { eventConsumers[it] = ArrayList() }
     }
 
-    fun getEventHandler(type: BusType, busName: String, consume: (Any) -> Unit): IEventHandlerBase {
+    fun getEventHandler(
+        type: BusType,
+        busName: String,
+        consume: ConsumerAction,
+        failureAction: FailureAction,
+    ): IEventHandlerBase {
         return when (type) {
             BusType.SQS -> {
-                val handler = SqsEventHandler(busName, consume, tabourAutoConfigs)
+                val handler = SqsEventHandler(busName, consume, tabourAutoConfigs, failureAction)
                 (eventConsumers[BusType.SQS] as ArrayList).add(handler)
                 handler
             }

--- a/src/main/kotlin/com/katanox/tabour/integration/sqs/core/consumer/SqsEventHandler.kt
+++ b/src/main/kotlin/com/katanox/tabour/integration/sqs/core/consumer/SqsEventHandler.kt
@@ -3,6 +3,7 @@ package com.katanox.tabour.integration.sqs.core.consumer
 import com.katanox.tabour.base.IEventHandlerBase
 import com.katanox.tabour.config.TabourAutoConfigs
 import com.katanox.tabour.extentions.ConsumerAction
+import com.katanox.tabour.extentions.FailureAction
 import com.katanox.tabour.extentions.retry
 import kotlinx.coroutines.runBlocking
 import org.springframework.context.annotation.Scope
@@ -15,6 +16,7 @@ class SqsEventHandler(
     val sqsQueueUrl: String = "",
     val consumerAction: ConsumerAction = {},
     val tabourConfigs: TabourAutoConfigs,
+    val failureAction: FailureAction,
 ) : IEventHandlerBase {
     /**
      * Called just before the handle() method is being called. You can implement this method to
@@ -43,5 +45,9 @@ class SqsEventHandler(
                 consumerAction(message)
             }
         }
+    }
+
+    fun onFailure(throwable: Throwable, message: Any) {
+        failureAction
     }
 }

--- a/src/main/kotlin/com/katanox/tabour/integration/sqs/core/consumer/SqsEventHandler.kt
+++ b/src/main/kotlin/com/katanox/tabour/integration/sqs/core/consumer/SqsEventHandler.kt
@@ -46,8 +46,4 @@ class SqsEventHandler(
             }
         }
     }
-
-    fun onFailure(throwable: Throwable, message: Any) {
-        failureAction
-    }
 }

--- a/src/main/kotlin/com/katanox/tabour/integration/sqs/core/consumer/SqsEventPoller.kt
+++ b/src/main/kotlin/com/katanox/tabour/integration/sqs/core/consumer/SqsEventPoller.kt
@@ -74,7 +74,7 @@ class SqsEventPoller(
             runCatching {
                 processMessage(message)
             }.onFailure { throwable ->
-                eventHandler.onFailure(throwable, message)
+                eventHandler.failureAction(throwable, message)
             }.onSuccess {
                 messagesToBeDeleted.add(
                     DeleteMessageBatchRequestEntry.builder().id(it.messageId())


### PR DESCRIPTION
…

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
This implementation gives the ability to perform different actions when a message consumption fails, by providing a default implementation for the fail cases that can be overridden by the implementer


## :bulb: Motivation and Context
#216 


## :green_heart: How did you test it?
Locally due to the lack of a testing suite


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

