### PR TITLE
Fix spring package

### DIFF
--- a/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
+++ b/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
@@ -45,7 +45,7 @@ class Tabour internal constructor(val config: Configuration) {
     fun updateRegistries(registries: Iterable<Registry<*>>) =
         this.apply {
             this.registries.clear()
-            this.registries.addAll(registries.toMutableSet())
+            this.registries.addAll(registries)
         }
 
     /**

--- a/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
+++ b/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.newFixedThreadPoolContext
  * By default, the container will allocate 4 threads which can be configured using [Configuration]
  */
 class Tabour internal constructor(val config: Configuration) {
-    val registries: MutableSet<Registry<*>> = mutableSetOf()
+    private val registries: MutableSet<Registry<*>> = mutableSetOf()
 
     @OptIn(DelicateCoroutinesApi::class)
     private val dispatcher: CoroutineDispatcher =

--- a/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
+++ b/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
@@ -42,6 +42,12 @@ class Tabour internal constructor(val config: Configuration) {
      */
     fun <T> register(registry: Registry<T>): Tabour = this.apply { registries.add(registry) }
 
+    fun updateRegistries(registries: Iterable<Registry<*>>) =
+        this.apply {
+            this.registries.clear()
+            this.registries.addAll(registries.toMutableSet())
+        }
+
     /**
      * Uses a registered SqsProducer to produce a message. The producer must be part of a sqs
      * registry that has been itself registered

--- a/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
+++ b/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.newFixedThreadPoolContext
  * By default, the container will allocate 4 threads which can be configured using [Configuration]
  */
 class Tabour internal constructor(val config: Configuration) {
-    private val registries: MutableSet<Registry<*>> = mutableSetOf()
+    val registries: MutableSet<Registry<*>> = mutableSetOf()
 
     @OptIn(DelicateCoroutinesApi::class)
     private val dispatcher: CoroutineDispatcher =

--- a/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
+++ b/core/src/main/kotlin/com/katanox/tabour/Tabour.kt
@@ -42,12 +42,6 @@ class Tabour internal constructor(val config: Configuration) {
      */
     fun <T> register(registry: Registry<T>): Tabour = this.apply { registries.add(registry) }
 
-    fun updateRegistries(registries: Iterable<Registry<*>>) =
-        this.apply {
-            this.registries.clear()
-            this.registries.addAll(registries)
-        }
-
     /**
      * Uses a registered SqsProducer to produce a message. The producer must be part of a sqs
      * registry that has been itself registered

--- a/spring/src/integrationTest/kotlin/com/katanox/tabour/spring/config/TabourConfigurerTest.kt
+++ b/spring/src/integrationTest/kotlin/com/katanox/tabour/spring/config/TabourConfigurerTest.kt
@@ -1,8 +1,8 @@
 package com.katanox.tabour.spring.config
 
+import com.katanox.tabour.configuration.core.tabour
 import com.katanox.tabour.configuration.sqs.sqsRegistry
 import com.katanox.tabour.configuration.sqs.sqsRegistryConfiguration
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,40 +10,26 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.ApplicationContext
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider
 import software.amazon.awssdk.regions.Region
 
 @ExperimentalCoroutinesApi
-@SpringBootTest(classes = [TabourConfigurer::class])
-@ExtendWith(SpringExtension::class)
-class TabourConfigurerTest(private val context: ApplicationContext) {
+class TabourConfigurerTest {
     @Test
     fun `test constructTabourContainer without annotation does not start tabour`() {
-        val tabourContainer =
-            constructTabourContainer(ClassWithoutAnnotation::class.java, 1) { emptyList() }
+        val tabourContainer = tabour { numOfThreads = 1 }
+
+        maybeLaunchTabour(ClassWithoutAnnotation::class.java, tabourContainer) { emptyList() }
 
         assertFalse(tabourContainer.running())
-        assertEquals(tabourContainer.config.numOfThreads, 1)
-    }
-
-    @Test
-    fun `test constructTabourContainer without annotation does not start tabour but assigns num of threads`() {
-        val tabourContainer =
-            constructTabourContainer(ClassWithoutAnnotation::class.java, 5) { emptyList() }
-
-        assertFalse(tabourContainer.running())
-        assertEquals(tabourContainer.config.numOfThreads, 5)
     }
 
     @Test
     fun `test constructTabourContainer with annotation but no registries does not start the container`() =
         runTest {
-            val tabourContainer =
-                constructTabourContainer(ClassWithAnnotation::class.java, 2) { emptyList() }
+            val tabourContainer = tabour { numOfThreads = 1 }
+
+            maybeLaunchTabour(ClassWithoutAnnotation::class.java, tabourContainer) { emptyList() }
 
             assertFalse(tabourContainer.running())
         }
@@ -51,18 +37,19 @@ class TabourConfigurerTest(private val context: ApplicationContext) {
     @Test
     fun `test constructTabourContainer with annotation and registries starts the container`() =
         runTest(UnconfinedTestDispatcher()) {
-            val tabourContainer =
-                constructTabourContainer(ClassWithAnnotation::class.java, 2) {
-                    listOf(
-                        sqsRegistry(
-                            sqsRegistryConfiguration(
-                                "",
-                                EnvironmentVariableCredentialsProvider.create(),
-                                Region.US_EAST_1
-                            )
+            val tabourContainer = tabour { numOfThreads = 1 }
+
+            maybeLaunchTabour(ClassWithAnnotation::class.java, tabourContainer) {
+                listOf(
+                    sqsRegistry(
+                        sqsRegistryConfiguration(
+                            "",
+                            EnvironmentVariableCredentialsProvider.create(),
+                            Region.US_EAST_1
                         )
                     )
-                }
+                )
+            }
 
             advanceUntilIdle()
 

--- a/spring/src/integrationTest/kotlin/com/katanox/tabour/spring/config/TabourConfigurerTest.kt
+++ b/spring/src/integrationTest/kotlin/com/katanox/tabour/spring/config/TabourConfigurerTest.kt
@@ -19,7 +19,7 @@ class TabourConfigurerTest {
     fun `test constructTabourContainer without annotation does not start tabour`() {
         val tabourContainer = tabour { numOfThreads = 1 }
 
-        maybeLaunchTabour(ClassWithoutAnnotation::class.java, tabourContainer) { emptyList() }
+        launchTabour(ClassWithoutAnnotation::class.java, tabourContainer) { emptyList() }
 
         assertFalse(tabourContainer.running())
     }
@@ -29,7 +29,7 @@ class TabourConfigurerTest {
         runTest {
             val tabourContainer = tabour { numOfThreads = 1 }
 
-            maybeLaunchTabour(ClassWithoutAnnotation::class.java, tabourContainer) { emptyList() }
+            launchTabour(ClassWithoutAnnotation::class.java, tabourContainer) { emptyList() }
 
             assertFalse(tabourContainer.running())
         }
@@ -39,7 +39,7 @@ class TabourConfigurerTest {
         runTest(UnconfinedTestDispatcher()) {
             val tabourContainer = tabour { numOfThreads = 1 }
 
-            maybeLaunchTabour(ClassWithAnnotation::class.java, tabourContainer) {
+            launchTabour(ClassWithAnnotation::class.java, tabourContainer) {
                 listOf(
                     sqsRegistry(
                         sqsRegistryConfiguration(

--- a/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
+++ b/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
@@ -42,7 +42,7 @@ class ContextRefreshedEventListener(
             val tabourContainers = context.getBeansOfType(Tabour::class.java)
 
             if (tabourContainers.size == 1) {
-                maybeLaunchTabour(mainClass, tabourContainers.values.first()) {
+                launchTabour(mainClass, tabourContainers.values.first()) {
                     context.getBeansOfType(Registry::class.java).values.toList()
                 }
             }
@@ -50,7 +50,11 @@ class ContextRefreshedEventListener(
     }
 }
 
-internal fun maybeLaunchTabour(
+/**
+ * starts the tabour container only if the annotation [AutoconfigureTabour] is present and there are
+ * [Registry] instances available in the spring context
+ */
+internal fun launchTabour(
     mainClass: Class<*>,
     tabourContainer: Tabour,
     registriesProvider: () -> List<Registry<*>>

--- a/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
+++ b/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
@@ -56,11 +56,14 @@ internal fun maybeLaunchTabour(
     registriesProvider: () -> List<Registry<*>>
 ) {
     val annotation = mainClass.getAnnotation(AutoconfigureTabour::class.java)
-    val registries = registriesProvider()
 
-    if (annotation != null && registries.isNotEmpty()) {
-        tabourContainer.updateRegistries(registries)
+    if (annotation != null) {
+        val registries = registriesProvider()
 
-        scope.launch { tabourContainer.start() }
+        if (registries.isNotEmpty()) {
+            tabourContainer.updateRegistries(registries)
+
+            scope.launch { tabourContainer.start() }
+        }
     }
 }

--- a/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
+++ b/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
@@ -41,17 +41,26 @@ class ContextRefreshedEventListener(
 
             val tabourContainers = context.getBeansOfType(Tabour::class.java)
 
-            val annotation = mainClass.getAnnotation(AutoconfigureTabour::class.java)
-
-            if (annotation != null && tabourContainers.size == 1) {
-                val container = tabourContainers.values.toList().first()
-
-                container.updateRegistries(
+            if (tabourContainers.size == 1) {
+                maybeLaunchTabour(mainClass, tabourContainers.values.first()) {
                     context.getBeansOfType(Registry::class.java).values.toList()
-                )
-
-                scope.launch { container.start() }
+                }
             }
         }
+    }
+}
+
+internal fun maybeLaunchTabour(
+    mainClass: Class<*>,
+    tabourContainer: Tabour,
+    registriesProvider: () -> List<Registry<*>>
+) {
+    val annotation = mainClass.getAnnotation(AutoconfigureTabour::class.java)
+    val registries = registriesProvider()
+
+    if (annotation != null && registries.isNotEmpty()) {
+        tabourContainer.updateRegistries(registries)
+
+        scope.launch { tabourContainer.start() }
     }
 }

--- a/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
+++ b/spring/src/main/kotlin/com/katanox/tabour/spring/config/TabourConfigurer.kt
@@ -61,9 +61,12 @@ internal fun maybeLaunchTabour(
         val registries = registriesProvider()
 
         if (registries.isNotEmpty()) {
-            tabourContainer.updateRegistries(registries)
-
-            scope.launch { tabourContainer.start() }
+            registries
+                .fold(tabourContainer) { container, registry -> container.register(registry) }
+                .apply {
+                    val container = this
+                    scope.launch { container.start() }
+                }
         }
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

Changed how we inject the tabour container in the spring context.
Previously we were injecting the tabour container on startup but there are cases where the application code needs more time to setup the dependencies which resulted in the tabour bean being created earlier and it could not find any registries at that time

This implementation starts the tabour immediately and then listens to a spring event in order to collect the registries and update them at runtime

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps